### PR TITLE
feat: export `SocketPacket` constructors

### DIFF
--- a/src/Erl/Kernel/Tcp.purs
+++ b/src/Erl/Kernel/Tcp.purs
@@ -3,7 +3,7 @@ module Erl.Kernel.Tcp
   , ConnectListenOptions
   , ConnectOptions
   , ListenOptions
-  , SocketPacket
+  , SocketPacket(..)
   , OptionToMaybe(..)
   , TcpSocket
   , TcpMessage(..)


### PR DESCRIPTION
So that we can use them for `listen` calls and the like.

There's not much point to hiding it and it's clear that these were meant to be constructed/used as they are part of `listen`/`listenPassive` options and so on.